### PR TITLE
updated module to allow depends_on & providers

### DIFF
--- a/examples/basic_container_registry_with_private_endpoint/main.tf
+++ b/examples/basic_container_registry_with_private_endpoint/main.tf
@@ -4,14 +4,6 @@
 #---------------------------------------------------------
 # Azure Region Lookup
 #----------------------------------------------------------
-module "mod_azure_region_lookup" {
-  source  = "azurenoops/overlays-azregions-lookup/azurerm"
-  version = "~> 1.0.0"
-
-  azure_region = "eastus"
-}
-
-
 module "acr" {
   depends_on = [
     azurerm_virtual_network.vnet

--- a/examples/basic_container_registry_with_private_endpoint/resource_dep.tf
+++ b/examples/basic_container_registry_with_private_endpoint/resource_dep.tf
@@ -4,6 +4,14 @@
 #-------------------------------------
 # VNET Creation - Default is "true"
 #-------------------------------------
+# This module is used to lookup the Azure Region based on the Azure Region Name
+module "mod_azure_region_lookup" {
+  source  = "azurenoops/overlays-azregions-lookup/azurerm"
+  version = "~> 1.0.0"
+
+  azure_region = "usgovvirginia"
+  
+}
 
 resource "azurerm_resource_group" "rg" {
   name     = "anoa-eus-dev-acr-dev-rg"
@@ -23,4 +31,5 @@ resource "azurerm_subnet" "subnet" {
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet.name
   address_prefixes     = ["10.0.100.0/24"]
+  private_endpoint_network_policies_enabled = false
 }

--- a/examples/basic_container_registry_with_private_endpoint/versions.tf
+++ b/examples/basic_container_registry_with_private_endpoint/versions.tf
@@ -13,4 +13,6 @@ terraform {
 
 provider "azurerm" {
   features {}
+  skip_provider_registration = true
+  environment = "USGovernment"
 }

--- a/resources.container.registry.private.endpoints.tf
+++ b/resources.container.registry.private.endpoints.tf
@@ -15,6 +15,7 @@ data "azurerm_subnet" "snet" {
   name                 = var.existing_private_subnet_name
   virtual_network_name = data.azurerm_virtual_network.vnet.0.name
   resource_group_name  = local.resource_group_name
+  
 }
 
 resource "azurerm_private_endpoint" "pep" {


### PR DESCRIPTION
## Describe your changes
edited /examples/basic_container_registry_with_private_endpoint/main.tf

removed
module "mod_azure_region_lookup" {
  source  = "azurenoops/overlays-azregions-lookup/azurerm"
  version = "~> 1.0.0"

  azure_region = "usgovvirginia"
  
}

and added it to /examples/basic_container_registry_with_private_endpoint/resource_dep.tf line 8-14
## Issue number

added this to examples/basic_container_registry_with_private_endpoint/resource_dep.tf for the subnet resource creation as its not allowed
private_endpoint_network_policies_enabled = false


added azure gov provider info in examples/basic_container_registry_with_private_endpoint/versions.tf


#000

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

